### PR TITLE
Clarify usage of '-' for profile deactivation

### DIFF
--- a/content/apt/guides/introduction/introduction-to-profiles.apt
+++ b/content/apt/guides/introduction/introduction-to-profiles.apt
@@ -311,6 +311,10 @@ mvn groupId:artifactId:goal -Denvironment=test
 +---+
 mvn groupId:artifactId:goal -P !profile-1,!profile-2,!?profile-3
 +---+
+  or
++---+
+mvn groupId:artifactId:goal -P -profile-1,-profile-2,-?profile-3
++---+
 
   This can be used to deactivate profiles marked as activeByDefault or profiles that would 
   otherwise be activated through their activation config.


### PR DESCRIPTION
With the introduction of "?" as an optionality indicator, the example for profile deactivation became slightly overloaded. To really demonstrate use of '-' (which is happily not interpreted by the shell, hence not requiring escaping), introduce a separate example.